### PR TITLE
Remove Django as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ CLASSIFIERS = [
 
 INSTALL_REQUIRES = [
   'requests>=2.8.1',
-  'Django>=1.10.6'
 ]
 
 


### PR DESCRIPTION
If I want to use the Flask integration, I don't want to pull in Django as a dependency.